### PR TITLE
Change deprecated set-output to use proposed env. file

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -120,8 +120,8 @@ runs:
             throw "Sorry, installing GCC is unsupported on $os"
         }
 
-        echo "::set-output name=gcc::$gcc"
-        echo "::set-output name=gxx::$gxx"
+        echo "gcc=$gcc" >> $env:GITHUB_OUTPUT
+        echo "gxx=$gxx" >> $env:GITHUB_OUTPUT
       shell: pwsh
 
     - run: |


### PR DESCRIPTION
The set-output command is deprecated and will be disabled soon.
For details see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

