### PR TITLE
fix: update action from deprecated behavior

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -120,9 +120,9 @@ runs:
             throw "Sorry, installing GCC is unsupported on $os"
         }
 
-        echo "gcc=$gcc" >> $GITHUB_OUTPUT
-        echo "gxx=$gxx" >> $GITHUB_OUTPUT
-        
+        echo "gcc=$gcc" >> $env:GITHUB_OUTPUT
+        echo "gxx=$gxx" >> $env:GITHUB_OUTPUT
+
       shell: pwsh
 
     - run: |

--- a/action.yml
+++ b/action.yml
@@ -120,8 +120,9 @@ runs:
             throw "Sorry, installing GCC is unsupported on $os"
         }
 
-        echo "::set-output name=gcc::$gcc"
-        echo "::set-output name=gxx::$gxx"
+        echo "gcc=$gcc" >> $GITHUB_OUTPUT
+        echo "gxx=$gxx" >> $GITHUB_OUTPUT
+        
       shell: pwsh
 
     - run: |


### PR DESCRIPTION
Fixes the action so GitHub doesn't print a warning about using deprecated behavior